### PR TITLE
Expected memory capacity is MB

### DIFF
--- a/documentation/dev/spec/protocol/inventory.md
+++ b/documentation/dev/spec/protocol/inventory.md
@@ -361,6 +361,7 @@ title: Inventory protocol
         <!ELEMENT MEMORIES (CAPACITY, CAPTION, FORMFACTOR, REMOVABLE, PURPOSE,
         SPEED, SERIALNUMBER, TYPE, DESCRIPTION, NUMSLOTS, MEMORYCORRECTION,
         MANUFACTURER)>
+          <!-- memory capacity, in MB -->
           <!ELEMENT CAPACITY (#PCDATA)>
           <!ELEMENT CAPTION (#PCDATA)>
           <!-- See Win32_PhysicalMemory documentation -->


### PR DESCRIPTION
Actually, as checked in the code, GLPI expects capacity in "Mio", even if memory module with capacity greater than 32Gb exists at that time, and the capacity displaying looks not very nice in that case.
FusionInventory Agent respects this hard-coded convention, so a comment here seems important.