### PR TITLE
Add missing dep

### DIFF
--- a/documentation/agent/installation/linux/deb.md
+++ b/documentation/agent/installation/linux/deb.md
@@ -47,7 +47,7 @@ For fusioninventory-agent, you'll need to install these dependencies:
 
     apt -y install dmidecode hwdata ucf hdparm
     apt -y install perl libuniversal-require-perl libwww-perl libparse-edid-perl
-    apt -y install libproc-daemon-perl libfile-which-perl
+    apt -y install libproc-daemon-perl libfile-which-perl libhttp-daemon-perl
     apt -y install libxml-treepp-perl libyaml-perl libnet-cups-perl libnet-ip-perl
     apt -y install libdigest-sha-perl libsocket-getaddrinfo-perl libtext-template-perl
 


### PR DESCRIPTION
Obviously, fusioninventory-agent need **libhttp-daemon-perl** package. On a Debian Stretch : 
``` sh
dpkg -i fusioninventory-agent_2.4-2_all.deb
Selecting previously unselected package fusioninventory-agent.
(Reading database ... 166015 files and directories currently installed.)
Preparing to unpack fusioninventory-agent_2.4-2_all.deb ...
Unpacking fusioninventory-agent (1:2.4-2) ...                                           
dpkg: dependency problems prevent configuration of fusioninventory-agent:
 fusioninventory-agent depends on libhttp-daemon-perl; however:
  Package libhttp-daemon-perl is not installed.
                                                                                                                                                                                                                                                                                 dpkg: error processing package fusioninventory-agent (--install):     
 dependency problems - leaving unconfigured                
Processing triggers for man-db (2.7.6.1-2) ...              
Errors were encountered while processing:     
 fusioninventory-agent
```