### PR TITLE
Add IMEI tag

### DIFF
--- a/documentation/dev/spec/protocol/inventory.md
+++ b/documentation/dev/spec/protocol/inventory.md
@@ -414,7 +414,7 @@ title: Inventory protocol
        <!ELEMENT MEMORYCORRECTION (#PCDATA)>
        <!ELEMENT MANUFACTURER (#PCDATA)>
 
-     <!ELEMENT MODEMS (NAME, DESCRIPTION, TYPE, MODEL, MANUFACTURER, SERIAL)>
+     <!ELEMENT MODEMS (NAME, DESCRIPTION, TYPE, MODEL, MANUFACTURER, SERIAL, IMEI)>
        <!-- modem name -->
        <!ELEMENT NAME (#PCDATA)>
        <!-- modem description if available -->
@@ -427,6 +427,8 @@ title: Inventory protocol
        <!ELEMENT MANUFACTURER (#PCDATA)>
        <!-- modem serial -->
        <!ELEMENT SERIAL (#PCDATA)>
+       <!-- IMEI information -->
+       <!ELEMENT IMEI (#PCDATA)>
 
      <!-- component firmwares -->
      <!ELEMENT FIRMWARES (NAME, DESCRIPTION, TYPE, VERSION, DATE, MANUFACTURER)>


### PR DESCRIPTION
Hi @ajsb85 @Ivans51

In this PR I add the IMEI tag to the fusioninventory documentation

Thank you

Related:

[#188](https://github.com/flyve-mdm/android-inventory-library/issues/188)
[#193](https://github.com/flyve-mdm/android-inventory-library/pull/193)
[#198](https://github.com/flyve-mdm/android-inventory-library/issues/198)