### PR TITLE
TAGGED Flag in VLAN

### DIFF
--- a/documentation/dev/spec/protocol/netinventory.md
+++ b/documentation/dev/spec/protocol/netinventory.md
@@ -185,11 +185,13 @@ title: Network inventory protocol
             <!-- VLANs list -->
             <!ELEMENT VLANS (VLAN+)>
               <!-- a VLAN -->
-              <!ELEMENT VLAN (NAME, NUMBER)>
+              <!ELEMENT VLAN (NAME, NUMBER, TAGGED)>
                 <!-- VLAN name (string) -->
                 <!ELEMENT NAME (#PCDATA)>
                 <!-- VLAN ID (integer) -->
                 <!ELEMENT NUMBER (#PCDATA)>
+                <!-- TAGGED flag (0|1) -->
+                <!Element TAGGED (#PCDATA)>
 
           <!ELEMENT MODEMS (NAME, DESCRIPTION, TYPE, MODEL, MANUFACTURER, SERIAL)>
             <!-- modem name -->


### PR DESCRIPTION
Add the ability to specify the Vlan is Tagged (Flag : 1) or Untagged (Flag : 0 or Element not present).
The link beetween Vlan and Port is already defined with Tagged flag in Glpi