### PR TITLE
Changes to the inventory protocol specs

### DIFF
--- a/documentation/dev/spec/protocol/inventory.md
+++ b/documentation/dev/spec/protocol/inventory.md
@@ -235,6 +235,10 @@ title: Inventory protocol
        <!ELEMENT CAPTION (#PCDATA)>
        <!-- manifacturer name -->
        <!ELEMENT MANUFACTURER (#PCDATA)>
+       <!-- device model -->
+       <!ELEMENT MODEL (#PCDATA)>
+       <!-- device serial number -->
+       <!ELEMENT SERIAL (#PCDATA)>
        <!-- device PCI class ID -->
        <!ELEMENT PCICLASS (#PCDATA)>
        <!-- device PCI vendor ID -->
@@ -411,6 +415,8 @@ title: Inventory protocol
        <!ELEMENT SPEED (#PCDATA)>
        <!-- memory serial number -->
        <!ELEMENT SERIALNUMBER (#PCDATA)>
+       <!-- memory model -->
+       <!ELEMENT MODEL (#PCDATA)>
        <!ELEMENT TYPE (#PCDATA)>
        <!ELEMENT DESCRIPTION (#PCDATA)>
        <!-- memory slot number -->


### PR DESCRIPTION
Current `CONTROLLERS` and `MEMORIES` structures lack some important fields - model and/or serial number. Particularly `CONTROLLERS` is missing both and all `fusioninventory-agent` does is provides chipset names and pci ids, which is not of much use from an inventory standpoint.

There is work in progress to introduce the mentioned fields in the agent: https://github.com/fusioninventory/fusioninventory-agent/pull/836
GLPI somewhat supports them too, in `DeviceMemoryModel` and `DeviceControlModel` classes which would need `getImportCriteria()` method updated.
`fusioninventory-for-glpi` would need a few updates to `PluginFusioninventoryInventoryComputerLib` and `PluginFusioninventoryFormatconvert`.